### PR TITLE
Clone and compare billy-b-assistant codebase

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -1,0 +1,117 @@
+### Billy-B Assistant: Codebase Comparison
+
+This document compares the external repository `billy-b-assistant` (cloned to `external/billy-b-assistant`) with the current workspace.
+
+---
+
+### Repos Compared
+- **Local**: root (`/workspace`)
+- **External**: `external/billy-b-assistant`
+
+---
+
+### High-level Summary
+- **Overall parity**: The local repo appears to be a refactored superset of the external codebase with additional modules for audio device handling, error handling, constants, websocket client, and OpenAI config abstraction.
+- **Entry point**: Both provide a `main.py`. Local adds structured logging, signal handling via helpers, and `.env` creation encapsulated; external performs these inline.
+- **Dependencies**: `requirements.txt` are identical across both, indicating runtime parity. Both also include a minimal `pyproject.toml` configuring Ruff.
+- **Web UI**: Both include a `webconfig/` Flask + static Tailwind UI with Node `package.json`. Local retains the same structure.
+
+---
+
+### Project Structure Differences
+
+- **Common directories/files** (present in both):
+  - `core/`: primary modules: `audio.py`, `button.py`, `config.py`, `ha.py`, `mic.py`, `movements.py`, `mqtt.py`, `personality.py`, `say.py`, `session.py`, `wakeup.py`
+  - `main.py`, `requirements.txt`, `pyproject.toml`, `persona.ini.example`, `versions.ini.example`
+  - `setup/` (systemd services, install scripts), `sounds/` (media assets), `docs/`, `test/`, `webconfig/` (Flask server, Tailwind assets)
+
+- **Local-only modules**:
+  - `core/audio_device_manager.py`
+  - `core/audio_playback.py`
+  - `core/audio_utils.py`
+  - `core/constants.py`
+  - `core/error_handling.py`
+  - `core/openai_config.py`
+  - `core/websocket_client.py`
+  - `REFACTORING_SUMMARY.md`
+
+- **External-only**:
+  - None observed at the top-level beyond minor file list differences inside `setup/` and static assets; core module set is a subset of local.
+
+---
+
+### Entry Point (`main.py`) Comparison
+
+- **External** highlights:
+  - Inline `.env` ensure/copy logic.
+  - Direct `signal` registrations for SIGINT/SIGTERM in-file.
+  - Uses `core.button.start_loop()`, `start_mqtt`, `start_motor_watchdog` directly.
+  - On fatal error: prints traceback, stops motors and MQTT directly.
+
+- **Local** highlights:
+  - Wraps `.env` creation in `ensure_env_file()` and loads via `dotenv`.
+  - Centralized logging and signal setup via `core.error_handling` (adds `setup_logging`, `setup_signal_handlers`, `safe_execute`, `log_error`, `cleanup_on_exit`).
+  - Same service bootstrap pattern (MQTT thread + motor watchdog + button loop) but with structured error handling and exit cleanup.
+
+**Impact**: Local emphasizes robustness, separation of concerns, and consistent logging; external is more direct/minimal.
+
+---
+
+### Core Modules: Notable Diffs
+
+- **Audio**: Local adds `audio_device_manager.py`, `audio_playback.py`, `audio_utils.py` suggesting improved device selection, buffering/queueing, and utility separation. External relies on `core/audio.py` and a `playback_queue` for coordination.
+
+- **Error Handling**: Local introduces `core/error_handling.py` and uses it across `main.py`. External handles signals and exceptions inline in `main.py`.
+
+- **Config and Constants**: Local adds `core/constants.py` and `core/openai_config.py`, hinting at centralized configuration and provider handling. External lacks these abstractions.
+
+- **Connectivity**: Local includes `core/websocket_client.py` (not present externally), indicating added real-time communication channels beyond MQTT.
+
+---
+
+### Dependencies and Tooling
+
+- `requirements.txt`:
+  - Identical in both:
+    - `sounddevice`, `websockets`, `numpy`, `scipy`, `gpiozero`, `python-dotenv`, `pydub`, `paho-mqtt`, `requests`, `openai`, `aiohttp`, `flask`, `lgpio`, `packaging`
+  - Implication: Runtime stack parity; local changes are structural/architectural rather than adding external libs.
+
+- `pyproject.toml`:
+  - Identical Ruff configuration (line length, indent width, lint rules, format rules).
+
+- Node/Web:
+  - Both `webconfig/package.json` present with `package-lock.json`. No observed divergence at listing level; deeper diff likely minimal.
+
+---
+
+### Setup and System Integration
+
+- Both include `setup/` with systemd service files and Wi-Fi provisioning scripts. Local retains `wifi_check.sh` and `wifi_setup.py` at the same paths.
+
+---
+
+### Tests and Docs
+
+- `test/replay.py` and `docs/BUILDME.md` mirror across both. Local has additional `REFACTORING_SUMMARY.md` documenting changes.
+
+---
+
+### Potential Migration Notes
+
+- Local introduces modularization for error handling, audio management, and constants; if backporting to external, extract these modules and update `main.py` wiring accordingly.
+- Given dependency parity, deployment behavior should remain compatible. Verify any new env vars referenced by `core/openai_config.py` and `core/constants.py`.
+- If leveraging `core/websocket_client.py`, ensure corresponding server-side counterpart exists and is configured.
+
+---
+
+### File Parity Snapshot
+
+- Same: `main.py`, `requirements.txt`, `pyproject.toml`, `core/{audio.py,button.py,config.py,ha.py,mic.py,movements.py,mqtt.py,personality.py,say.py,session.py,wakeup.py}`, `webconfig/*`, `setup/*`, `sounds/*`, `test/replay.py`, `docs/*`.
+- Added locally: `core/{audio_device_manager.py,audio_playback.py,audio_utils.py,constants.py,error_handling.py,openai_config.py,websocket_client.py}`, `REFACTORING_SUMMARY.md`.
+
+---
+
+### Conclusion
+
+The local repository builds on the external `billy-b-assistant` by adding resilience, modularity, and optional realtime connectivity, while keeping the same dependency footprint and overall functionality.
+


### PR DESCRIPTION
Add `COMPARISON.md` and `external/billy-b-assistant` submodule to compare codebases.

---
<a href="https://cursor.com/background-agent?bcId=bc-87a39719-6e70-4c97-8b70-f318fd8636ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87a39719-6e70-4c97-8b70-f318fd8636ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

